### PR TITLE
Close SPI in RFID cleanup

### DIFF
--- a/RFID.py
+++ b/RFID.py
@@ -346,4 +346,5 @@ class RFID:
         if self.authed:
             self.stop_crypto()
         GPIO.cleanup()
+        SPI.closeSPI()
 


### PR DESCRIPTION
Fixes: After a few times working properly the box stops playing music even when the NFC tag is detected