### PR TITLE
Automate process of flashing sd card

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+IMAGE = https\://github\.com/hypriot/image-builder-rpi/releases/download/v1\.11\.1/hypriotos-rpi-v1\.11\.1\.img\.zip
+
+.PHONY: flash
+
+flash:
+	flash --userdata setup/image/config.yml --bootconf setup/image/boot.txt $(IMAGE)

--- a/README.md
+++ b/README.md
@@ -52,9 +52,19 @@ reconnect (or connect to it via LAN).
 
 ### Base OS
 
-The code was built and tested with Raspian Jessie (2016-05-27).
-
+The code was built and tested with Raspbian Jessie (2016-05-27).
 Enable the SPI interface using `sudo raspi-config`, then go to `Advanced Options` and enable SPI.
+
+Alternatively, you can also flash a [hypriot image](https://blog.hypriot.com) (Raspbian Buster including a working installation of docker) by use of the [hypriot flash](https://github.com/hypriot/flash) utility.
+The configuration files used in this process are located under `setup/image`.
+To use it to flash an sd card, just run
+
+```
+make flash
+```
+
+and follow the prompts.
+No worries about enabling interfaces anymore. :)
 
 ### System packages
 

--- a/setup/image/boot.txt
+++ b/setup/image/boot.txt
@@ -1,0 +1,10 @@
+hdmi_force_hotplug=1
+enable_uart=0
+
+# Camera settings, see http://elinux.org/RPiconfig#Camera
+start_x=0
+disable_camera_led=1
+gpu_mem=16
+
+dtparam=audio=on
+dtparam=spi=on

--- a/setup/image/config.yml
+++ b/setup/image/config.yml
@@ -1,3 +1,4 @@
+#cloud-config
 # vim: syntax=yaml
 ---
 hostname: nfcmusic
@@ -9,10 +10,7 @@ users:
     gecos: nfcmusic service run user
     sudo: ALL=(ALL) NOPASSWD:ALL
     shell: /bin/bash
-    groups:
-      - users
-      - docker
-      - audio
+    groups: users,docker,audio
     plain_text_passwd: nfcmusic
     lock_passwd: false
     ssh_pwauth: true

--- a/setup/image/config.yml
+++ b/setup/image/config.yml
@@ -1,0 +1,20 @@
+# vim: syntax=yaml
+---
+hostname: nfcmusic
+locale: en_US.UTF-8
+manage_etc_hosts: true
+package_upgrade: false
+users:
+  - name: nfcmusic
+    gecos: nfcmusic service run user
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    groups:
+      - users
+      - docker
+      - audio
+    plain_text_passwd: nfcmusic
+    lock_passwd: false
+    ssh_pwauth: true
+    chpasswd:
+      expire: false


### PR DESCRIPTION
Use hypriot rather than raspbian base image.
Rationale: The hypriot image gives us a working docker installation.
And why not run the nfcmusik management service in a docker container
anyway rather than installing it 'the usual way' directly onto the system?